### PR TITLE
Fix extra block inserted when getting out of the list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ export default class Checklist {
         currentItem.remove();
 
         this.api.blocks.insert();
-        this.api.caret.setToBlock(currentBlockIndex + 1);
+        this.api.caret.setToBlock(currentBlockIndex);
 
         return;
       }


### PR DESCRIPTION
Currently checklist insert one extra block when getting out of list. This should be similar to https://github.com/editor-js/list/blob/58b5dc7072ad92a048ebe9488d0ca8e7bfa069d2/src/index.js#L417